### PR TITLE
AOS-weekly-totals

### DIFF
--- a/niddk_covid_sicr/prep.py
+++ b/niddk_covid_sicr/prep.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+import datetime # AOS added
+import calendar
 import numpy as np
 import math
 from numpy.random import gamma, exponential, lognormal,normal
@@ -53,6 +55,70 @@ def get_stan_data(full_data_path, args):
         stan_data['ts'] += offset
     return stan_data, df['dates2'][t0]
 
+def get_stan_data_weekly_total(full_data_path, args):
+    """ Get weekly totals for new cases, recoveries,
+        and deaths from timeseries data.
+    """
+    df = pd.read_csv(full_data_path)
+    if getattr(args, 'last_date', None):
+        try:
+            datetime.strptime(args.last_date, '%m/%d/%y')
+        except ValueError:
+            msg = "Incorrect --last-date format, should be MM/DD/YY"
+            raise ValueError(msg)
+        else:
+            df = df[df['dates2'] <= args.last_date]
+
+    # t0 := where to start time series, index space
+    try:
+        t0 = np.where(df["new_cases"].values >= 5)[0][0]
+    except IndexError:
+        return [None, None]
+    # tm := start of mitigation, index space
+
+    try:
+        dfm = pd.read_csv(args.data_path / 'mitigationprior.csv')
+        tmdate = dfm.loc[dfm.region == args.roi, 'date'].values[0]
+        tm = np.where(df["dates2"] == tmdate)[0][0]
+    except Exception:
+        print("Could not use mitigation prior data; setting mitigation prior to default.")
+        tm = t0 + 10
+
+    n_proj = 120
+    stan_data = {}
+
+    week_frame_total = math.floor((len(df['dates2'])/7))*7 # find num rows that fit (mod 7)
+    if len(df) != week_frame_total: # if we have dates that spill over our weekly chunks,
+        df.drop([week_frame_total, len(df)-1], inplace=True) # drop them
+    df['Date'] = pd.to_datetime(df['dates2']) # used to calculate leading week
+    df.set_index('Date', inplace=True) # need this for df.resample()
+
+    start_day = df.index[0] - datetime.timedelta(1)
+    start_day = start_day.strftime("%A")
+    start_abr = start_day.upper()[:3] # get 3 letter abbrev
+
+    df['weeklytotal_new_cases'] = df.new_cases.resample('W-{}'.format(start_abr)).sum()
+    df['weeklytotal_new_recover'] = df.new_recover.resample('W-{}'.format(start_abr)).sum()
+    df['weeklytotal_new_deaths'] = df.new_deaths.resample('W-{}'.format(start_abr)).sum()
+    df.reset_index(inplace=True) # reset index for df.groupby()
+    df = df.bfill(axis ='rows') # backfill nan to fill weeklytotal columns with
+                                    # weekly totals
+    stan_data['n_ostates'] = 3
+    stan_data['tm'] = tm
+    stan_data['ts'] = np.arange(t0, len(df['dates2']) + n_proj)
+    stan_data['y'] = df[['weeklytotal_new_cases', 'weeklytotal_new_recover',
+                    'weeklytotal_new_deaths']].to_numpy().astype(int)[t0:, :]
+    stan_data['n_obs'] = len(df['dates2']) - t0
+    stan_data['n_weeks'] = math.floor((len(df['dates2']) - t0)/7)
+    stan_data['n_total'] = len(df['dates2']) - t0 + n_proj
+    if args.fixed_t:
+        global_start = datetime.strptime('01/22/20', '%m/%d/%y')
+        frame_start = datetime.strptime(df['dates2'][0], '%m/%d/%y')
+        offset = (frame_start - global_start).days
+        stan_data['tm'] += offset
+        stan_data['ts'] += offset
+
+    return stan_data, df['dates2'][t0]
 
 def get_n_data(stan_data):
     if stan_data:

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -68,7 +68,6 @@ assert csv.exists(), "No such csv file: %s" % csv
 stan_data, t0 = ncs.get_stan_data(csv, args)
 if args.totwk:
     stan_data, t0 = ncs.get_stan_data_weekly_total(csv, args)
-exit()
 if stan_data is None:
     print("No data for %s; skipping fit." % args.roi)
     sys.exit(0)

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -52,6 +52,8 @@ parser.add_argument('-ft', '--fixed-t', type=int, default=0,
                     help=('Use a fixed time base (where 1/22/20 is t=0)'
                           'rather than a time base that is relative to the '
                           'beginning of the data for each region'))
+parser.add_argument('-tw', '--totwk', action="store_true",
+                   help=('Use weekly totals for new cases, recoveries and deaths'))
 args = parser.parse_args()
 
 if args.n_threads == 0:
@@ -64,6 +66,9 @@ csv = csv.resolve()
 assert csv.exists(), "No such csv file: %s" % csv
 
 stan_data, t0 = ncs.get_stan_data(csv, args)
+if args.totwk:
+    stan_data, t0 = ncs.get_stan_data_weekly_total(csv, args)
+exit()
 if stan_data is None:
     print("No data for %s; skipping fit." % args.roi)
     sys.exit(0)


### PR DESCRIPTION
Created flag (-tw', '--totwk) in scripts/run.py for getting weekly, non-overlapping totals for new cases, recoveries and deaths and creates Stan data for this for modeling. (original branch name was AOS-weekly-nonoverlapping-average)