### PR TITLE
calculate weekly totals

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -67,7 +67,7 @@ assert csv.exists(), "No such csv file: %s" % csv
 
 stan_data, t0 = ncs.get_stan_data(csv, args)
 if args.totwk:
-    stan_data, t0 = ncs.get_stan_data_weekly_total(csv, args)
+    stan_data, t0 = ncs.get_stan_data_weekly_total(csv, args, args.data_path, args.roi)
 if stan_data is None:
     print("No data for %s; skipping fit." % args.roi)
     sys.exit(0)


### PR DESCRIPTION
calculate weekly totals for roi(s) if -tw flag is used in run.py. Weekly total timeseries files get saved in folder called Path(data-path) + "_weekly". This folder is helpful for using notebooks with weekly data so you don't need to rename columns.