### PR TITLE
AOS-change-filterdefault-getdata

### DIFF
--- a/niddk_covid_sicr/data.py
+++ b/niddk_covid_sicr/data.py
@@ -30,7 +30,7 @@ def get_jhu(data_path: str, filter_: Union[dict, bool] = True) -> None:
     url_template = ("https://raw.githubusercontent.com/CSSEGISandData/"
                     "COVID-19/master/csse_covid_19_data/"
                     "csse_covid_19_time_series/time_series_covid19_%s_%s.csv")
-
+                    
     # Scrape the data
     dfs = {}
     for region in ['global', 'US']:

--- a/scripts/get-data.py
+++ b/scripts/get-data.py
@@ -14,7 +14,7 @@ parser.add_argument('-s', '--sources', default=['jhu', 'covid-tracking', 'canada
                     nargs='+', help='Data sources to use.')
 # parser.add_argument('-s', '--sources', default=['jhu', 'covid-tracking', 'canada'],
 #                     nargs='+', help='Data sources to use.')
-parser.add_argument('-fi', '--filter', default=1, type=int,
+parser.add_argument('-fi', '--filter', default=0, type=int,
                     help='Whether or not to filter based on data thresholds')
 parser.add_argument('-fn', '--fix-negatives', default=0, type=int,
                     help=("Whether or not to fix negative values "


### PR DESCRIPTION
Changing filter flag default in get-data.py to 0 so it includes regions like Sweden, Samoa, etc. Regions where recovery data is not provided. These regions will now get added to data path. Recovery data for these timeseries files is labeled -1. 