### PR TITLE
Creating flag for setting start/end dates

### DIFF
--- a/niddk_covid_sicr/prep.py
+++ b/niddk_covid_sicr/prep.py
@@ -66,6 +66,19 @@ def get_stan_data_weekly_total(full_data_path, args):
         else:
             df = df[df['dates2'] <= args.last_date]
 
+    if getattr(args, 'first_last_date', None):
+        try:
+            date_range = args.first_last_date.split(" ") # split on whitespace
+            start_date = datetime.strptime(date_range[0], '%m/%d/%y')
+            end_date = datetime.strptime(date_range[1], '%m/%d/%y')
+        except ValueError:
+            msg = """Incorrect --first_last_date format, should be MM/DD/YY
+            MM/DD/YY where first date is start date, followed by a whitespace,
+            followed by last date"""
+            raise ValueError(msg)
+        else:
+            df = df[(df['dates2'] >= date_range[0]) & (df['dates2'] <= date_range[1])]
+
     n_proj = 120
     stan_data = {}
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -45,6 +45,12 @@ parser.add_argument('-i', '--init',
 parser.add_argument('-ld', '--last-date',
                     help=('Last date to use in the data; dates past this '
                           'will be ignored'))
+parser.add_argument('-fld', '--first-last-date',
+                    help=('First and last dates to use in the data; dates before '
+                          'and after will be ignored. Format must be this: '
+                           'MM/DD/YY MM/DD/YY where first date is start date.'
+                           'Use Sundays and Saturdays for start and end dates'
+                           ' respectively.'))
 parser.add_argument('-nd', '--n-data-only',
                     help=('Only calculate number of data points used for each'
                           'region, write to a table, and stop before fitting'))


### PR DESCRIPTION
Adding to run.py a flag called '-fld' ('-first-last-date') which allows user to set date range. Works with '-tw' weekly totals data. Start date should be a Sunday and end date should be a Saturday so it fits neatly with weekly totals sampling. For example, to run with US_NY and any model starting on July 5, 2020 to November 21, 2021:

python scripts/run.py model -r='US_NY' -tw -fld='07/05/20 11/21/21'