### PR TITLE
AOS-fix-flag

### DIFF
--- a/niddk_covid_sicr/analysis.py
+++ b/niddk_covid_sicr/analysis.py
@@ -81,23 +81,24 @@ def make_table(roi: str, samples: pd.DataFrame, params: list, stats: dict,
         else:
             df = samples[cols]
             if by_week:
-                if day_offset:
-                    padding = pd.DataFrame(None, index=df.index, columns=['padding_%d' % i for i in range(day_offset)])
-                    df = padding.join(df)
-                #     min_periods = 4
-                # else:
-                #     min_periods = 7
-                # if df.shape[1] >= 7:  # At least one week worth of data
-                #     # Column 6 will be the last day of the first week
-                #     # It will contain the average of the first week
-                #     # Do this every 7 days
-                #     df = df.T.rolling(7, min_periods=min_periods).mean().T.iloc[:, 6::7]
-                # else:
-                #     # Just use the last value we have
-                #     df = df.T.rolling(7, min_periods=min_periods).mean().T.iloc[:, -1:]
-                #     # And then null it because we don't want to trust < 1 week
-                #     # of data
-                #     df[:] = None
+                if not args.totwk:
+                    if day_offset:
+                        padding = pd.DataFrame(None, index=df.index, columns=['padding_%d' % i for i in range(day_offset)])
+                        df = padding.join(df)
+                        min_periods = 4
+                    else:
+                        min_periods = 7
+                    if df.shape[1] >= 7:  # At least one week worth of data
+                        # Column 6 will be the last day of the first week
+                        # It will contain the average of the first week
+                        # Do this every 7 days
+                        df = df.T.rolling(7, min_periods=min_periods).mean().T.iloc[:, 6::7]
+                    else:
+                        # Just use the last value we have
+                        df = df.T.rolling(7, min_periods=min_periods).mean().T.iloc[:, -1:]
+                        # And then null it because we don't want to trust < 1 week
+                        # of data
+                        df[:] = None
                 df.columns = ['%s (week %d)' % (param, i)
                               for i in range(len(df.columns))]
             try:

--- a/niddk_covid_sicr/analysis.py
+++ b/niddk_covid_sicr/analysis.py
@@ -100,9 +100,11 @@ def make_table(roi: str, samples: pd.DataFrame, params: list, stats: dict,
                 #     df[:] = None
                 print("#####################")
                 print(roi)
+                print(df)
                 print(df.columns)
                 df.columns = ['%s (week %d)' % (param, i)
                               for i in range(len(df.columns))]
+                print(df)
                 exit()
             try:
                 df = df.describe(percentiles=quantiles)

--- a/niddk_covid_sicr/analysis.py
+++ b/niddk_covid_sicr/analysis.py
@@ -98,14 +98,8 @@ def make_table(roi: str, samples: pd.DataFrame, params: list, stats: dict,
                 #     # And then null it because we don't want to trust < 1 week
                 #     # of data
                 #     df[:] = None
-                print("#####################")
-                print(roi)
-                print(df)
-                print(df.columns)
                 df.columns = ['%s (week %d)' % (param, i)
                               for i in range(len(df.columns))]
-                print(df)
-                exit()
             try:
                 df = df.describe(percentiles=quantiles)
             except ValueError as e:

--- a/niddk_covid_sicr/analysis.py
+++ b/niddk_covid_sicr/analysis.py
@@ -45,7 +45,7 @@ def get_top_n(
 
 def make_table(roi: str, samples: pd.DataFrame, params: list, stats: dict,
                quantiles: list = [0.025, 0.25, 0.5, 0.75, 0.975],
-               chain: [int, None] = None, day_offset=1) -> pd.DataFrame:
+               chain: [int, None] = None, day_offset=0) -> pd.DataFrame:
     """Make a table summarizing the fit.
 
     Args:

--- a/niddk_covid_sicr/analysis.py
+++ b/niddk_covid_sicr/analysis.py
@@ -22,7 +22,7 @@ def get_top_n(
     exclude_us_states=False,
 ):
     """Get the top N regions, by total case count, up to a certain date.
-    
+
     last_data: Use 'YYYY/MM/DD' format.
     """
     rois = list_rois(data_path, prefix, extension)
@@ -45,7 +45,7 @@ def get_top_n(
 
 def make_table(roi: str, samples: pd.DataFrame, params: list, stats: dict,
                quantiles: list = [0.025, 0.25, 0.5, 0.75, 0.975],
-               chain: [int, None] = None, day_offset=0) -> pd.DataFrame:
+               chain: [int, None] = None, day_offset=1) -> pd.DataFrame:
     """Make a table summarizing the fit.
 
     Args:
@@ -84,20 +84,20 @@ def make_table(roi: str, samples: pd.DataFrame, params: list, stats: dict,
                 if day_offset:
                     padding = pd.DataFrame(None, index=df.index, columns=['padding_%d' % i for i in range(day_offset)])
                     df = padding.join(df)
-                    min_periods = 4
-                else:
-                    min_periods = 7
-                if df.shape[1] >= 7:  # At least one week worth of data
-                    # Column 6 will be the last day of the first week
-                    # It will contain the average of the first week
-                    # Do this every 7 days
-                    df = df.T.rolling(7, min_periods=min_periods).mean().T.iloc[:, 6::7]
-                else:
-                    # Just use the last value we have
-                    df = df.T.rolling(7, min_periods=min_periods).mean().T.iloc[:, -1:]
-                    # And then null it because we don't want to trust < 1 week
-                    # of data
-                    df[:] = None
+                #     min_periods = 4
+                # else:
+                #     min_periods = 7
+                # if df.shape[1] >= 7:  # At least one week worth of data
+                #     # Column 6 will be the last day of the first week
+                #     # It will contain the average of the first week
+                #     # Do this every 7 days
+                #     df = df.T.rolling(7, min_periods=min_periods).mean().T.iloc[:, 6::7]
+                # else:
+                #     # Just use the last value we have
+                #     df = df.T.rolling(7, min_periods=min_periods).mean().T.iloc[:, -1:]
+                #     # And then null it because we don't want to trust < 1 week
+                #     # of data
+                #     df[:] = None
                 df.columns = ['%s (week %d)' % (param, i)
                               for i in range(len(df.columns))]
             try:

--- a/niddk_covid_sicr/analysis.py
+++ b/niddk_covid_sicr/analysis.py
@@ -98,8 +98,12 @@ def make_table(roi: str, samples: pd.DataFrame, params: list, stats: dict,
                 #     # And then null it because we don't want to trust < 1 week
                 #     # of data
                 #     df[:] = None
+                print("#####################")
+                print(roi)
+                print(df.columns)
                 df.columns = ['%s (week %d)' % (param, i)
                               for i in range(len(df.columns))]
+                exit()
             try:
                 df = df.describe(percentiles=quantiles)
             except ValueError as e:

--- a/scripts/get-n-data.py
+++ b/scripts/get-n-data.py
@@ -15,6 +15,9 @@ parser.add_argument('-ft', '--fixed-t', type=int, default=0,
                     help=('Use a fixed time base (where 1/22/20 is t=0)'
                           'rather than a time base that is relative to the '
                           'beginning of the data for each region'))
+parser.add_argument('-tw', '--totwk', action="store_true",
+                   help=('Use weekly totals for new cases, recoveries and deaths'))
+
 args = parser.parse_args()
 
 
@@ -28,7 +31,10 @@ for roi in rois:
     csv = Path(args.data_path) / ("covidtimeseries_%s.csv" % roi)
     csv = csv.resolve()
     assert csv.exists(), "No such csv file: %s" % csv
-    stan_data, t0 = ncs.get_stan_data_weekly_total(csv, args)
+    if not args.towk:
+        stan_data, t0 = ncs.get_stan_data(csv, args)
+    if args.towk:
+        stan_data, t0 = ncs.get_stan_data_weekly_total(csv, args)
     n_data = ncs.get_n_data(stan_data)
     df.loc[roi, 'n_data_pts'] = int(n_data)
     df.loc[roi, 't0'] = t0

--- a/scripts/get-n-data.py
+++ b/scripts/get-n-data.py
@@ -15,7 +15,7 @@ parser.add_argument('-ft', '--fixed-t', type=int, default=0,
                     help=('Use a fixed time base (where 1/22/20 is t=0)'
                           'rather than a time base that is relative to the '
                           'beginning of the data for each region'))
-parser.add_argument('-tw', '--totwk', action="store_true",
+parser.add_argument('-tw', '--totwk', type=int, default=1,
                    help=('Use weekly totals for new cases, recoveries and deaths'))
 
 args = parser.parse_args()
@@ -31,9 +31,9 @@ for roi in rois:
     csv = Path(args.data_path) / ("covidtimeseries_%s.csv" % roi)
     csv = csv.resolve()
     assert csv.exists(), "No such csv file: %s" % csv
-    if not args.towk:
+    if not args.totwk:
         stan_data, t0 = ncs.get_stan_data(csv, args)
-    if args.towk:
+    if args.totwk:
         stan_data, t0 = ncs.get_stan_data_weekly_total(csv, args)
     n_data = ncs.get_n_data(stan_data)
     df.loc[roi, 'n_data_pts'] = int(n_data)

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from p_tqdm import p_map
 from pathos.helpers import cpu_count
 import warnings
+import math
 warnings.simplefilter("ignore")
 
 import niddk_covid_sicr as ncs
@@ -91,7 +92,8 @@ def roi_df(args, model_name, roi):
         stan_data, t0 = ncs.get_stan_data(csv, args)
         global_start = datetime.strptime('01/22/20', '%m/%d/%y')
         frame_start = datetime.strptime(t0, '%m/%d/%y')
-        day_offset = (frame_start - global_start).days
+        # day_offset = (frame_start - global_start).days
+        day_offset = math.floor((frame_start - global_start).days/7) # for weeks
     else:
         day_offset = 0
     model_path = ncs.get_model_path(args.models_path, model_name)

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -55,6 +55,8 @@ parser.add_argument('-ao', '--average-only', type=int, default=0,
                     help=('Assume all of the model-specific tables already '
                           'exist, skip creating them and instead make only '
                           'the concatenated (raw) and reweighted tables'))
+parser.add_argument('-tw', '--totwk', action="store_true",
+                   help=('Use weekly totals for new cases, recoveries and deaths'))
 args = parser.parse_args()
 
 # Max jobs
@@ -89,11 +91,18 @@ def roi_df(args, model_name, roi):
         csv = Path(args.data_path) / ("covidtimeseries_%s.csv" % args.roi)
         csv = csv.resolve()
         assert csv.exists(), "No such csv file: %s" % csv
-        stan_data, t0 = ncs.get_stan_data(csv, args)
+        if not args.totwk:
+            stan_data, t0 = ncs.get_stan_data(csv, args)
+        if args.towk:
+            stan_data, t0 = ncs.get_stan_data_weekly_total(csv, args)
+
         global_start = datetime.strptime('01/22/20', '%m/%d/%y')
         frame_start = datetime.strptime(t0, '%m/%d/%y')
-        # day_offset = (frame_start - global_start).days
-        day_offset = math.floor((frame_start - global_start).days/7) # for weeks
+
+        if not args.totwk:
+            day_offset = (frame_start - global_start).days
+        if args.totwk:
+            day_offset = math.floor((frame_start - global_start).days/7) # for weeks
     else:
         day_offset = 0
     model_path = ncs.get_model_path(args.models_path, model_name)

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -55,7 +55,7 @@ parser.add_argument('-ao', '--average-only', type=int, default=0,
                     help=('Assume all of the model-specific tables already '
                           'exist, skip creating them and instead make only '
                           'the concatenated (raw) and reweighted tables'))
-parser.add_argument('-tw', '--totwk', action="store_true",
+parser.add_argument('-tw', '--totwk', type=int, default=1,
                    help=('Use weekly totals for new cases, recoveries and deaths'))
 args = parser.parse_args()
 
@@ -93,7 +93,7 @@ def roi_df(args, model_name, roi):
         assert csv.exists(), "No such csv file: %s" % csv
         if not args.totwk:
             stan_data, t0 = ncs.get_stan_data(csv, args)
-        if args.towk:
+        if args.totwk:
             stan_data, t0 = ncs.get_stan_data_weekly_total(csv, args)
 
         global_start = datetime.strptime('01/22/20', '%m/%d/%y')

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -81,7 +81,6 @@ if stan_data is None:
 if args.n_data_only:
     print(ncs.get_n_data(stan_data))
     sys.exit(0)
-exit()
 init_fun = ncs.get_init_fun(args, stan_data)
 
 model_path = Path(args.models_path) / ('%s.stan' % args.model_name)

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -58,7 +58,7 @@ parser.add_argument('-ft', '--fixed-t', type=int, default=0,
                     help=('Use a fixed time base (where 1/22/20 is t=0)'
                           'rather than a time base that is relative to the '
                           'beginning of the data for each region'))
-parser.add_argument('-tw', '--totwk', action="store_true",
+parser.add_argument('-tw', '--totwk', type=int, default=1,
                    help=('Use weekly totals for new cases, recoveries and deaths'))
 args = parser.parse_args()
 
@@ -71,7 +71,7 @@ csv = Path(args.data_path) / ("covidtimeseries_%s.csv" % args.roi)
 csv = csv.resolve()
 assert csv.exists(), "No such csv file: %s" % csv
 
-if not args.towk:
+if not args.totwk:
     stan_data, t0 = ncs.get_stan_data(csv, args)
 if args.totwk:
     stan_data, t0 = ncs.get_stan_data_weekly_total(csv, args)
@@ -81,6 +81,7 @@ if stan_data is None:
 if args.n_data_only:
     print(ncs.get_n_data(stan_data))
     sys.exit(0)
+exit()
 init_fun = ncs.get_init_fun(args, stan_data)
 
 model_path = Path(args.models_path) / ('%s.stan' % args.model_name)

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -71,7 +71,8 @@ csv = Path(args.data_path) / ("covidtimeseries_%s.csv" % args.roi)
 csv = csv.resolve()
 assert csv.exists(), "No such csv file: %s" % csv
 
-stan_data, t0 = ncs.get_stan_data(csv, args)
+if not args.towk:
+    stan_data, t0 = ncs.get_stan_data(csv, args)
 if args.totwk:
     stan_data, t0 = ncs.get_stan_data_weekly_total(csv, args)
 if stan_data is None:


### PR DESCRIPTION
Fix -totwk (weekly totals) flag so the following scripts default to handling weekly data, unless specified otherwise (-tw=0): get-n-data.py, run.py, maketables.py.