### PR TITLE
AOS-fix-model-averaging

### DIFF
--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -216,7 +216,7 @@ def roi_df_averaging(args, model_name, roi):
     else:
         day_offset = 0
 
-    samples = pd.read_csv(args.fits_path f'/DiscreteAverage_{roi}.csv')
+    samples = pd.read_csv(args.fits_path + f'/DiscreteAverage_{roi}.csv')
     stats = ncs.get_waic(samples)
     df = ncs.make_table(roi, samples, args.params, args.totwk,
                         stats, quantiles=args.quantiles,

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -265,16 +265,14 @@ if args.model_averaging: # Perform model averaging using raw fit file
     # mimic other tables code and merge reweighted table with model averaged table
     # replace applicable regions with model averaged results
     # Get all model_names, roi combinations
-    combos = []
+
     extension = ['csv', 'pkl'][0] # use 'csv'
     rois = ncs.list_rois(Path(args.fits_path), 'DiscreteAverage', extension)
-    print(rois)
     mods = tuple(['DiscreteAverage' for x in rois])
     rois = tuple(rois)
+    combos = []
     combos.append(mods)
     combos.append(rois)
-    # combos = [('DiscreteAverage', 'DiscreteAverage'), ('Cameroon', 'Paraguay')] # TESTING
-    print(combos)
     assert len(combos), "No combinations of models and ROIs found for model averaging"
     result = p_map(roi_df_averaging, repeat(args), *combos, num_cpus=args.max_jobs)
     tables = [df_ for model_name_, roi, df_ in result]

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -203,19 +203,15 @@ if args.model_averaging: # Perform model averaging using raw fit file
         weights_out = tables_path / ('weights_for_averaging.csv')
         df_weights.to_csv(weights_out)
         roi_model_combos = ncs.get_fits_path_weights(df_weights)
-        print(roi_model_combos)
         # load fits and extract samples per roi we have weights for
         for roi,models in roi_model_combos.items():
             dfs = []
             for model_name in models:
                 model_path = ncs.get_model_path(args.models_path, model_name)
-                print(model_path)
                 extension = ['csv', 'pkl'][args.fit_format]
                 fit_path = ncs.get_fit_path(args.fits_path, model_name, roi)
-                print(fit_path)
                 df_roi = df_weights.loc[roi]
                 model_name_weight = model_name + '_weight'
-                print(model_name_weight)
                 weight = df_roi[model_name_weight]
 
                 if args.fit_format == 1:
@@ -244,9 +240,12 @@ if args.model_averaging: # Perform model averaging using raw fit file
         extension = ['csv', 'pkl'][0] # use 'csv'
         rois = ncs.list_rois(Path(args.fits_path), 'DiscreteAverage', extension)
         combos += [('Discrete1', roi) for roi in rois]
+        print(combos)
         combos = list(zip(*combos)) # Organize into (model_name, roi) tuples
+        print(combos)
         assert len(combos), "No combinations of models and ROIs found for model averaging"
         result = p_map(roi_df, repeat(args), *combos, num_cpus=args.max_jobs)
+        print(result)
         tables = [df_ for model_name_, roi, df_ in result]
         if len(tables) > 1:
             df_averaged = pd.concat(tables)

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -271,7 +271,7 @@ if args.model_averaging: # Perform model averaging using raw fit file
     print(rois)
     combos += [('Discrete1', roi) for roi in rois]
     combos = list(zip(*combos)) # Organize into (model_name, roi) tuples
-    combos = [('DiscreteAverage', 'Cameroon'), ('DiscreteAverage', 'Paraguay')] # TESTING
+    combos = [('DiscreteAverage', 'DiscreteAverage'), ('Cameroon', 'Paraguay')] # TESTING
     print(combos)
     assert len(combos), "No combinations of models and ROIs found for model averaging"
     result = p_map(roi_df_averaging, repeat(args), *combos, num_cpus=args.max_jobs)

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -203,6 +203,7 @@ if args.model_averaging: # Perform model averaging using raw fit file
         weights_out = tables_path / ('weights_for_averaging.csv')
         df_weights.to_csv(weights_out)
         roi_model_combos = ncs.get_fits_path_weights(df_weights)
+        print(roi_model_combos)
         # load fits and extract samples per roi we have weights for
         for roi,models in roi_model_combos.items():
             dfs = []

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -85,6 +85,7 @@ if not args.average_only:
         combos += [(model_name, roi) for roi in rois]
     # Organize into (model_name, roi) tuples
     combos = list(zip(*combos))
+    print(combos)
     assert len(combos), "No combinations of models and ROIs found"
     print("There are %d combinations of models and ROIs" % len(combos))
 

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -239,9 +239,11 @@ if args.model_averaging: # Perform model averaging using raw fit file
         combos = []
         extension = ['csv', 'pkl'][0] # use 'csv'
         rois = ncs.list_rois(Path(args.fits_path), 'DiscreteAverage', extension)
+        print(rois)
         combos += [('Discrete1', roi) for roi in rois]
         combos = list(zip(*combos)) # Organize into (model_name, roi) tuples
         combos = [('DiscreteAverage', 'Cameroon'), ('DiscreteAverage', 'Paraguay')]
+        print(combos)
         assert len(combos), "No combinations of models and ROIs found for model averaging"
         result = p_map(roi_df, repeat(args), *combos, num_cpus=args.max_jobs)
         tables = [df_ for model_name_, roi, df_ in result]

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -245,7 +245,6 @@ if args.model_averaging: # Perform model averaging using raw fit file
         print(combos)
         assert len(combos), "No combinations of models and ROIs found for model averaging"
         result = p_map(roi_df, repeat(args), *combos, num_cpus=args.max_jobs)
-        print(result)
         tables = [df_ for model_name_, roi, df_ in result]
         if len(tables) > 1:
             df_averaged = pd.concat(tables)

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -209,10 +209,13 @@ if args.model_averaging: # Perform model averaging using raw fit file
             dfs = []
             for model_name in models:
                 model_path = ncs.get_model_path(args.models_path, model_name)
+                print(model_path)
                 extension = ['csv', 'pkl'][args.fit_format]
                 fit_path = ncs.get_fit_path(args.fits_path, model_name, roi)
+                print(fit_path)
                 df_roi = df_weights.loc[roi]
                 model_name_weight = model_name + '_weight'
+                print(model_name_weight)
                 weight = df_roi[model_name_weight]
 
                 if args.fit_format == 1:

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -85,7 +85,6 @@ if not args.average_only:
         combos += [(model_name, roi) for roi in rois]
     # Organize into (model_name, roi) tuples
     combos = list(zip(*combos))
-    print(combos)
     assert len(combos), "No combinations of models and ROIs found"
     print("There are %d combinations of models and ROIs" % len(combos))
 

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -239,6 +239,7 @@ if args.model_averaging: # Perform model averaging using raw fit file
         combos = []
         extension = ['csv', 'pkl'][0] # use 'csv'
         rois = ncs.list_rois(Path(args.fits_path), 'DiscreteAverage', extension)
+        print(rois)
         combos += [('Discrete1', roi) for roi in rois]
         print(combos)
         combos = list(zip(*combos)) # Organize into (model_name, roi) tuples

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -239,11 +239,9 @@ if args.model_averaging: # Perform model averaging using raw fit file
         combos = []
         extension = ['csv', 'pkl'][0] # use 'csv'
         rois = ncs.list_rois(Path(args.fits_path), 'DiscreteAverage', extension)
-        print(rois)
         combos += [('Discrete1', roi) for roi in rois]
-        print(combos)
         combos = list(zip(*combos)) # Organize into (model_name, roi) tuples
-        print(combos)
+        combos = [('DiscreteAverage', 'Cameroon'), ('DiscreteAverage', 'Paraguay')]
         assert len(combos), "No combinations of models and ROIs found for model averaging"
         result = p_map(roi_df, repeat(args), *combos, num_cpus=args.max_jobs)
         tables = [df_ for model_name_, roi, df_ in result]

--- a/scripts/make-tables.py
+++ b/scripts/make-tables.py
@@ -269,9 +269,11 @@ if args.model_averaging: # Perform model averaging using raw fit file
     extension = ['csv', 'pkl'][0] # use 'csv'
     rois = ncs.list_rois(Path(args.fits_path), 'DiscreteAverage', extension)
     print(rois)
-    combos += [('Discrete1', roi) for roi in rois]
-    combos = list(zip(*combos)) # Organize into (model_name, roi) tuples
-    combos = [('DiscreteAverage', 'DiscreteAverage'), ('Cameroon', 'Paraguay')] # TESTING
+    mods = tuple(['DiscreteAverage' for x in rois])
+    rois = tuple(rois)
+    combos.append(mods)
+    combos.append(rois)
+    # combos = [('DiscreteAverage', 'DiscreteAverage'), ('Cameroon', 'Paraguay')] # TESTING
     print(combos)
     assert len(combos), "No combinations of models and ROIs found for model averaging"
     result = p_map(roi_df_averaging, repeat(args), *combos, num_cpus=args.max_jobs)


### PR DESCRIPTION
Fixed bug in model averaging code where only stats from Discrete1 were being reported regardless of pre-calculated weights.